### PR TITLE
Add ROS prototype to production on Ubuntu Core series

### DIFF
--- a/96boards.org/Projects/ROSProductionUbuntuCore/README.md
+++ b/96boards.org/Projects/ROSProductionUbuntuCore/README.md
@@ -1,0 +1,38 @@
+# ROS prototype to production on Ubuntu Core
+
+Follow along in this five-part series as Kyle takes you from creating a
+Robot Operating System (ROS) prototype on classic Ubuntu to creating a
+flashable Ubuntu Core image with the prototype preinstalled. Along the way
+you'll learn about ROS, snaps, and Ubuntu Core.
+
+## Project Details
+
+- **Creator:** Kyle Fazzari
+- **Project Name:** ROS prototype to production on Ubuntu Core
+- **Type of Project:** Tutorial
+- **Project Category:** Robotics
+- **Board(s) used:** DragonBoard 410C
+- **Difficulty level:** Intermediate
+
+## Videos
+
+- [Part 1: ROS Prototype to Production on Ubuntu Core](https://youtu.be/x6BkzfwOZbc?list=PL1LO5F1-Jh8K6R1Ba23irALtey6CRFFYu)
+- [Part 2: Our prototype](https://youtu.be/QFrOXd2avfo?list=PL1LO5F1-Jh8K6R1Ba23irALtey6CRFFYu)
+- [Part 3: Our prototype as a snap](https://youtu.be/Dw1aqbucPbY?list=PL1LO5F1-Jh8K6R1Ba23irALtey6CRFFYu)
+- [Part 4: Obtaining confined access to the Turtlebot](https://youtu.be/m9wqj34-2go?list=PL1LO5F1-Jh8K6R1Ba23irALtey6CRFFYu)
+- [Part 5: Create an Ubuntu Core image with our snap preinstalled](https://youtu.be/NUackegFqWQ?list=PL1LO5F1-Jh8K6R1Ba23irALtey6CRFFYu)
+
+## Resources
+
+Blog series (if you don't want to follow the videos):
+- [From ROS prototype to production on Ubuntu Core [1/5]](https://insights.ubuntu.com/2017/04/06/from-ros-prototype-to-production-on-ubuntu-core/)
+- [ROS production: our prototype [2/5]](https://insights.ubuntu.com/2017/04/13/ros-production-our-prototype/)
+- [ROS production: our prototype as a snap [3/5]](https://insights.ubuntu.com/2017/04/21/ros-production-our-prototype-as-a-snap-35/)
+- [ROS production: obtaining confined access to the Turtlebot [4/5]](https://insights.ubuntu.com/2017/04/27/ros-production-obtaining-confined-access-to-the-turtlebot-45/)
+- [ROS production: create an Ubuntu Core image preinstalled with our snap [5/5]](https://insights.ubuntu.com/2017/05/09/ros-production-create-ubuntu-core-image-with-snap-preinstalled-55/)
+
+### Social Media Links
+
+- Kyle Fazzari: [Blog](https://kyrofa.com) &#124; [Twitter](https://twitter.com/rainveil) &#124; [Facebook](https://www.facebook.com/fazzari.kyle) &#124; [Linkedin](www.linkedin.com/in/kylefazzari) &#124; [G+](https://plus.google.com/+KyleFazzari) &#124; [YouTube](youtube.com/c/KyleFazzari)
+
+***


### PR DESCRIPTION
This PR resolves #6 by adding the "ROS prototype to production on Ubuntu Core" series to the list of projects.