### PR TITLE
Fixes broken links to Camera Mezzanine datasheets.

### DIFF
--- a/_product/mezzanine/d3camera/README.md
+++ b/_product/mezzanine/d3camera/README.md
@@ -22,7 +22,7 @@ D3 Engineering DesignCore™ Camera Mezzanine Board OV5640 enables direct connec
 - Camera Interfaces: Two MIPI CSI-2 (2-lane)
 - Expansion Interfaces: Two UART, two SPI, one I2C, one PCM, GPIO.
 - [Designcore Camera Mezzanine WIKI](https://github.com/D3Engineering/410c_camera_support/wiki)
-- Datasheet and Schematics ([View](https://github.com/96boards/website/blob/master/96boards.org/Products/Mezzanine/D3Camera/Files/D3Eng_DesignCore_CamMezzBoard_DataSheet.pdf) / [Download](https://github.com/96boards/website/raw/master/96boards.org/Products/Mezzanine/D3Camera/Files/D3Eng_DesignCore_CamMezzBoard_DataSheet.pdf))
-- OV5640 Quickstart Guide ([View](https://github.com/96boards/website/blob/master/96boards.org/Products/Mezzanine/D3Camera/Files/D3Eng_DesignCore_CamMezzBoard_OV5640_QuickStart_Guide_v1.pdf) / [Download](https://github.com/96boards/website/raw/master/96boards.org/Products/Mezzanine/D3Camera/Files/D3Eng_DesignCore_CamMezzBoard_OV5640_QuickStart_Guide_v1.pdf))
+- Datasheet and Schematics ([View](https://github.com/96boards/website/blob/master/_product/mezzanine/d3camera/files/D3Eng_DesignCore_CamMezzBoard_DataSheet.pdf) / [Download](https://github.com/96boards/website/raw/master/_product/mezzanine/d3camera/files/D3Eng_DesignCore_CamMezzBoard_DataSheet.pdf))
+- OV5640 Quickstart Guide ([View](https://github.com/96boards/website/blob/master/_product/mezzanine/d3camera/files/D3Eng_DesignCore_CamMezzBoard_OV5640_QuickStart_Guide_v1.pdf) / [Download](https://github.com/96boards/website/raw/master/_product/mezzanine/d3camera/files/D3Eng_DesignCore_CamMezzBoard_OV5640_QuickStart_Guide_v1.pdf))
 
 ***


### PR DESCRIPTION
I noticed the View/Download links on the Camera Mezzanine page were broken, so I fixed them! :D I haven't checked to see if the other links on other pages are also broken or not yet.