### PR TITLE
Added Mezzanine guidelines link to html and .md

### DIFF
--- a/_product/mezzanine/README.md
+++ b/_product/mezzanine/README.md
@@ -5,6 +5,8 @@ description: |-
     96Boards mezzanine products let you expand your Consumer Edition or Enterprise
     Edition 96Boards with new interfaces for IoT, industrial control, and other
     embedded applications. The following mezzanine expansion boards are currently available.
+    
+Please take some time to review our [mezzanine guidelines](https://github.com/96boards/documentation/raw/master/mezzanine/files/mezzanine-design-guidelines.pdf) document for some helpful design guidelines and resources.
 specification-logo-path: /images/96Boards-Logo_Partner-small.png
 ---
 
@@ -13,6 +15,8 @@ specification-logo-path: /images/96Boards-Logo_Partner-small.png
 
 96Boards mezzanine products let you expand your [Consumer Edition](https://www.96boards.org/products/ce/) or [Enterprise Edition](https://www.96boards.org/products/ee/) 96Boards with new interfaces for IoT, industrial control, and other
 embedded applications. The following mezzanine expansion boards are currently available.
+
+Please take some time to review our [mezzanine guidelines](https://github.com/96boards/documentation/raw/master/mezzanine/files/mezzanine-design-guidelines.pdf) document for some helpful design guidelines and resources.
 
 ***
 

--- a/_product/mezzanine/mezzanine.html
+++ b/_product/mezzanine/mezzanine.html
@@ -7,6 +7,8 @@ description: |-
     96Boards mezzanine products let you expand your Consumer Edition or Enterprise
     Edition 96Boards with new interfaces for IoT, industrial control, and other
     embedded applications. The following mezzanine expansion boards are currently available.
+
+Please take some time to review our [mezzanine guidelines](https://github.com/96boards/documentation/raw/master/mezzanine/files/mezzanine-design-guidelines.pdf) document for some helpful design guidelines and resources.
 specification-logo: 96Boards-Logo_Partner-small.png
 redirect_from:
 - /products/mezzanine/new-doc/


### PR DESCRIPTION
Link to Mezzanine guidelines has been added to mezzanine
landing page and html file in mezzanine folder.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>