### PR TITLE
Fixed SFO17 go page and OpenHours update

### DIFF
--- a/go/sfo17-connect-reach/README.md
+++ b/go/sfo17-connect-reach/README.md
@@ -14,21 +14,21 @@ layout: empty-container-page-no-nav
 - Learn about our single board computers that are tremendous for developers in such domains as Robotics, Makerspace, embedded Firmware, Automotive, IoT and more 
 - Win the chance to get free 96boards at the event or learn a method for discounted 96boards in the future
 
-## SESSION 1: SFO17-XYZ
+## SESSION 1: Intro to Linaro and 96Boards for Engineers
 
 - **Time**: Thursday 2:00p-2:30p
 - **Title**: Intro to Linaro and 96Boards for Engineers
 - **Presenter(s)**: Mike Levine and Robert Wolff
 - **Summary**: Having been around for so long already, many who view keynotes and sessions are jumping in at a bit of a learning curve. This session will take the explanation of Linaro and 96Boards back to basics. Focusing on the what, why, and how things get done within these two segments at a very high level.
 
-# SESSION 2: SFO17-XYZ
+## SESSION 2: 96Boards OpenHours Pre-game
 
 - **Time**: Thursday 2:30p-3:00p
 - **Title**: 96Boards OpenHours Pre-game
 - **Presenter(s)**: Robert Wolff
 - **Summary**: OpenHours pregame special will be a fun look back at what got us to this point. This is an ideal opportunity to get up to speed with the over 40 previously aired episodes. There will be a simple presentation with social media links and announcements as well as a fun video montage. Expect open discussion, and a sneak peak of our featured guests for the "Live in San Francisco" show later that day.
 
-## SESSION 3: SFO17-XYZ
+## SESSION 3: OpenHours Live in San Francisco!
 
 - **Time**: Thursday 3:00p-4:00p
 - **Title**: OpenHours Live in San Francisco!
@@ -37,13 +37,13 @@ layout: empty-container-page-no-nav
 
 ## Resources
 
-- About Linaro the parent company of 96Boards:  https://www.linaro.org/about/
-- About 96Boards: http://www.96boards.org/about/
-- About Openhours:  http://www.96boards.org/openhours/
+- About Linaro the parent company of 96Boards:  [https://www.linaro.org/about/](https://www.linaro.org/about/)
+- About 96Boards: [http://www.96boards.org/about/](http://www.96boards.org/about/)
+- About Openhours:  [http://www.96boards.org/openhours/](http://www.96boards.org/openhours/)
 
 We are looking to develop rapports with embedded firmware engineers in San Francisco. This endeavor of ours should lead to more community members for 96Boards to help us accomplish various projects using 96Boards. The event will take place in San Francisco at the Hyatt Regency Hotel, [read more here](http://connect.linaro.org/).
 
 To attend the Thursday the 28th of August sessions free of charge listed above click here to register:  all about Linaro and 96Boards click here: 
 
 
-https://goo.gl/forms/c7CSD2GxxORObOJK2
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSc6Ekv-1sJe_57XqUMgIbQMSLXVwDmPXi7ByAP-NghaXl-tNw/viewform?embedded=true" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>

--- a/openhours/README.md
+++ b/openhours/README.md
@@ -14,12 +14,9 @@ js-vendor: openhours
 <div class="open-hours-clock"></div>
 <a href="http://link.linaro.org/openhoursjoin" class="btn blog-read-more-btn center-block">Click Here to Join OpenHours</a>
 
-### This week – [ADD TO CALENDAR](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=cWxyNWlsZzFibDVwZzNrZjJ0b2s5aWtjdm9fMjAxNzA4MTdUMTYwMDAwWiBhMXFxdjZqaHIxYTBhdDJzbGxuazVpNzRpNEBn&tmsrc=a1qqv6jhr1a0at2sllnk5i74i4%40group.calendar.google.com)
+### This week – [ADD TO CALENDAR](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=cWxyNWlsZzFibDVwZzNrZjJ0b2s5aWtjdm9fMjAxNzA4MjRUMTYwMDAwWiBhMXFxdjZqaHIxYTBhdDJzbGxuazVpNzRpNEBn&tmsrc=a1qqv6jhr1a0at2sllnk5i74i4%40group.calendar.google.com)
 
-**OpenHours Episode #66** - Come, tell the world about Monero and Kovri! Share your Linaro / 96boards experience! In this episode we will discuss the work accomplished by the Kovri / Monero team and community as well as what collaborations are in store for the future.
-
-Monero is a community-driven cryptocurrency designed to deliver always-on fungibility, privacy, and anonymity. Monero’s Kovri I2P Router Project provides users with the ability to run and access nodes that hide their geographic location and IP address. When used in conjunction with Kovri, the origin of Monero transactions is concealed to protect the privacy of the sender while mitigating network monitoring and other attacks. Cross-platform support is made possible by automating builds and testing on Linaro/96boards systems.
-/u/fluffyponyza, /u/hyc_symas and /u/anonimal_0x914409F1 are confirmed for the call. All are welcome!
+**OpenHours Episode #67** - In this episode, we will get in touch with our roots! Q&A with the 96Boards OpenHours team, some resource walkthrough and possible a demo or two. This week is all about talking some tech while hanging out and having fun. We look forward to seeing you there!
 
 Don’t forget to join us in our new [OpenHours IRC channel](https://webchat.freenode.net/): **#OpenHours & #96boards**
 
@@ -48,7 +45,7 @@ The 96Boards Team
 <div class="openhours-panel" markdown="1">
 ### When
 
-Every Thursday at 4pm UTC – [ADD TO CALENDAR](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=cWxyNWlsZzFibDVwZzNrZjJ0b2s5aWtjdm9fMjAxNzA4MTdUMTYwMDAwWiBhMXFxdjZqaHIxYTBhdDJzbGxuazVpNzRpNEBn&tmsrc=a1qqv6jhr1a0at2sllnk5i74i4%40group.calendar.google.com)
+Every Thursday at 4pm UTC – [ADD TO CALENDAR](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=cWxyNWlsZzFibDVwZzNrZjJ0b2s5aWtjdm9fMjAxNzA4MjRUMTYwMDAwWiBhMXFxdjZqaHIxYTBhdDJzbGxuazVpNzRpNEBn&tmsrc=a1qqv6jhr1a0at2sllnk5i74i4%40group.calendar.google.com)
 
 ### How to Join
 


### PR DESCRIPTION
Fixed some formatting issues in the SFO17 go page and added embedded link to
sign up form. Added the new description and calendar link to the OpenHours ep 67
page.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>