### PR TITLE
product/mezzanine/secure96: removed occurance of OP-TEE

### DIFF
--- a/_product/mezzanine/secure96/README.md
+++ b/_product/mezzanine/secure96/README.md
@@ -49,8 +49,6 @@ This mezzanine board is intended for security development on 96Boards and featur
    - 1.8V
 - Analog Input (V)
    - 0V-1.8V
-- OS Support
-   - OPTEE
 - Size
    - 60x30mm
 


### PR DESCRIPTION
All occurance of OP-TEE has been removed from the README
for Secure96 Mezzanine

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>