### PR TITLE
posts/2017/12: Changed title to ET2017 Blog

### DIFF
--- a/_posts/2017/12/2017-12-01-et2017.md
+++ b/_posts/2017/12/2017-12-01-et2017.md
@@ -1,5 +1,5 @@
 ---
-title: Title
+title: 96Boards goes to Japan!
 author: Robert Wolff
 date: 2017-12-01 01:00:00+00:00
 image:


### PR DESCRIPTION
The only thing changed in this PR is the title for the blog. From "Title" to "96Boards goes to Japan!"

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>