### PR TITLE
go: Added two new go pages

### DIFF
--- a/go/2018-partnership-brazil/README.md
+++ b/go/2018-partnership-brazil/README.md
@@ -1,0 +1,133 @@
+---
+title: Brazil Partnership - 2018
+description: |-
+    96Boards Compliance is designed to ensure a level of hardware and software functionality and quality for the 96Boards Community Board program.
+permalink: /go/brazil-partnership-2018/
+layout: empty-container-page-no-nav
+---
+## Brazil Partnership - 2018
+
+<div class="center-block" markdown="1">
+{% include image.html name="BrazilPartnershipGoImg1.jpg" alt="Dragonboard410c Partnership Brazil Image 1"%}
+
+{% include image.html name="BrazilPartnershipGoImg2.jpg" alt="Dragonboard410c Partnership Brazil Image 2"%}
+
+<a href="http://link.linaro.org/openhoursjoin" class="btn btn-primary">Click Here to Join Partnership Open Forum</a>
+</div>
+
+<div class="col-md-9" markdown="1">
+
+## The IoT Hardware Kit
+
+[More information available at Embarcados Brazil](https://contest.embarcados.com.br/inventando-o-futuro-com-dragonboard-410c/)
+
+Each team participating in the challenge will be able to check out one hack kit containing:
+
+## Open Forum for all participants!
+
+**The 96Boards team will be hosting a live open forum, every week until the end of the partnership program. The open forum will last from 1-2 hours each week. All are welcome to come hang out and get your questions answered!**
+
+### When?
+
+Every Thursday at 5:30pm UTC – [ADD TO CALENDAR](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=dWVjbGtyMXJndXZidG5tZG1jcGo5cmtpNGdfMjAxNzA2MjJUMTczMDAwWiByb2JlcnQud29sZmZAbGluYXJvLm9yZw&tmsrc=robert.wolff%40linaro.org) (this link will change each week)
+
+### How to Join
+
+**To join the Meeting:**  
+[http://link.linaro.org/openhoursjoin](http://link.linaro.org/openhoursjoin)
+
+**To join via phone :**  
+1\. Dial: +1.408.740.7256 or 943216362  
+2\. Enter the meeting ID: 943216362
+
+([More numbers](http://bluejeans.com/numbers?ll=en) +1.888.240.2560 or +1.408.317.9253)
+
+You may also visit [BlueJeans to download the application](https://www.bluejeans.com/downloads)
+
+## **Provided in Kit:**
+
+*   [DragonBoard 410c](https://developer.qualcomm.com/hardware/dragonboard-410c), by Arrow Electronics, featuring the Qualcomm® Snapdragon™ 410 processor
+*   [Arrow LinkSprite]()https://www.96boards.org/product/linker-mezzanine-starter-kit/
+
+**Optional Addons to help development:**
+
+*   [96Boards LinkSprite Kit](https://www.arrow.com/en/products/96boards-starter-kit/linksprite-technologies-inc)
+*   [96Boards Audio Mezzanine](https://www.arrow.com/en/products/audiomezz/seeed-technology-limited)
+*   [96Boards Camera Mezzanine](https://www.arrow.com/en/products/b-f446e-96b01a/stmicroelectronics)
+*   96Boards [Sensors Mezzanine Adapter by Seeed](https://www.seeedstudio.com/item_detail.html?p_id=2617)
+*   96Boards [UART Adapter Board by Seeed](http://www.seeedstudio.com/depot/96Boards-UART-p-2525.html)
+*   [HDMI to VGA converter](http://www.comtac.com.br/produto/conversor-hdmi-para-vga-udio)
+*   Breadboard with jumper wires: [IB401 400-point Experiment Breadboard, microtivity](http://www.microtivity.com/p/IB401/400-point-experiment-breadboard-w-jumper-wires)
+*   Voltage-level translator: [SparkFun Voltage-Level Translator Breakout – TXB0104](https://www.sparkfun.com/products/11771)
+*   Logic Level Converter Bi-Directional: [SparkFun Logic Level Converter – Bi-Directional – BOB-12009](https://www.sparkfun.com/products/12009)
+*   Sensors and accessories:
+    *   [Grove 10DoF (Accel, Gyro, Mag, Pressure, Temperature) IMU](http://www.seeedstudio.com/depot/Grove-IMU-10DOF-p-2386.html)
+    *   [Grove Digital Light Sensor](http://www.seeedstudio.com/depot/Grove-Digital-Light-Sensor-p-1281.html) (see [Grove Digital Light I2C Sensor Application Note](https://developer.qualcomm.com/download/db410c/interfacing-grove-digital-light-i2c-sensor-application-note.pdf) for tips on enabling this)
+    *   [Grove Gesture Sensor](http://www.seeedstudio.com/depot/Grove-Gesture-p-2463.html)
+    *   [Grove I2C Color Sensor](http://www.seeedstudio.com/depot/Grove-I2C-Color-Sensor-p-854.html)
+    *   [Grove Button Sensor](http://www.seeedstudio.com/depot/Grove-Button-p-766.html)
+    *   [Grove Buzzer Sensor](http://www.seeedstudio.com/wiki/Grove_-_Buzzer)
+    *   [Grove Sound Sensor](http://www.seeedstudio.com/wiki/Grove_-_Sound_Sensor)
+    *   [Grove Touch Sensor](http://www.seeedstudio.com/wiki/Grove_-_Touch_Sensor)
+    *   [Grove Rotary Angle Sensor](http://www.seeedstudio.com/wiki/Grove_-_Rotary_Angle_Sensor)
+    *   [Grove Smart Relay](http://www.seeedstudio.com/wiki/Grove_-_Relay)
+    *   [Grove Mini Servo](http://www.seeedstudio.com/wiki/Grove_-_Servo)
+    *   [Grove LCD RGB Backlight](http://www.seeedstudio.com/wiki/Grove_-_LCD_RGB_Backlight)
+    *   [I2C Hub](http://www.seeedstudio.com/depot/Grove-I2C-Hub-p-851.html)
+    *   [Grove 4-pin Male Jumper to Grove 4-pin Conversion Cable](http://www.seeedstudio.com/depot/Grove-4-pin-Male-Jumper-to-Grove-4-pin-Conversion-Cable-5-PCs-per-Pack-p-1565.html)
+*   Wireless keyboard with touchpad: [Logitech Wireless Touch Keyboard K400](http://www.logitech.com/en-us/product/wireless-touch-keyboard-k400r)
+
+## Resources
+
+**Getting started:**
+
+*   [DragonBoard 410c Landing page](https://www.96boards.org/product/dragonboard410c/) – here you will find getting started documents and more…
+*   Linux installation – select the Micro SD card with Linux from your hack kit and follow the instructions in the [DragonBoard 410c Linux User Guide](https://github.com/96boards/documentation/blob/master/ConsumerEdition/DragonBoard-410c/Guides/LinuxUserGuide_DragonBoard.pdf) to install from a microSD card, skipping the initial download steps because we’ve done that work for you.
+*   Android installation – Android is preloaded on the DragonBoard 410c. If you remove Android and wish to re-install it, visit the Qualcomm table to get a Micro SD card with Android. Then follow the instructions in the [DragonBoard 410c Android User Guide](https://github.com/96boards/documentation/blob/master/ConsumerEdition/DragonBoard-410c/Guides/AndroidUserGuide_DragonBoard.pdf) to install from a microSD card, skipping the initial download steps because we’ve done that work for you.
+*   [Instructables (Previous projects)](http://www.instructables.com/howto/dragonboard+qualcomm/)
+*   [Workshop presentation](http://bit.ly/2lzW7ox)
+
+**Connectivity:**
+
+*   Instructions for [internet connections over USB](https://github.com/96boards/documentation/wiki/Sharing-Internet-connections-over-USB-on-96Boards) are available on GitHub
+
+**Peripherals access and sample code:**
+
+*   A repository of [sample code for sensors](https://github.com/DBOpenSource/db_samples) included in the hack kit is available on Github
+*   [GPIO and I2C libraries and installation]()https://www.96boards.org/documentation/ConsumerEdition/CE-Extras/GPIO/README.md/ are available on GitHub with beginner and advanced instructions for building 96BoardsGPIO, libsoc, libmraa, and libupm. These libraries can be used for GPIO and I2C access.
+*   [Low-speed expansion header tutorial]()https://www.96boards.org/documentation/ConsumerEdition/CE-Extras/GPIO/LSExpansionHeader/README.md offers a quick read about the 96Boards low-speed expansion header to get you familiar with the header and the various interfaces available on the header.
+*   Compact getting started blogs:
+    *   [96Boards mezzanine products](https://www.96boards.org/blog/96boards-box-experience-guide-3/)
+    *   [General Purpose Input/Output (GPIO)](https://www.96boards.org/blog/96boards-box-experience-guide-4/)
+    *   [96Boards enabled libraries (libsoc, libmraa,UPM)](https://www.96boards.org/blog/96boards-box-experience-guide-5/)
+    *   [Programing I2C devices with libmraa and libupm](https://www.96boards.org/blog/programing-i2c-devices-libmraa-libupm/)
+*   Instructions for [getting started with AT&T M2X](https://github.com/ArrowElectronics/att-iot-device-sdk) on the DragonBoard 410c are available on GitHub
+
+**Documentation:**
+
+*   Visit 96Boards.org for [DragonBoard 410c documentation](https://www.96boards.org/products/ce/dragonboard410c/)
+*   Release Notes for [Linaro Linux](https://github.com/96boards/documentation/blob/master/ConsumerEdition/DragonBoard-410c/Guides/LinuxUserGuide_DragonBoard.pdf) based on Ubuntu
+*   Release Notes for [Android](https://github.com/96boards/documentation/blob/master/ConsumerEdition/DragonBoard-410c/Guides/AndroidUserGuide_DragonBoard.pdf)
+
+**Support:**
+
+*   Visit the [DragonBoard 410c support forum](https://discuss.96boards.org/c/products/dragonboard410c/) on 96Boards.org
+*   [Live chat with 96Boards and Linaro developers](https://webchat.freenode.net/) (you will need to create a temp user name and join channel #96boards #OpenHours)
+*   **[View the OpenHours video recordings](https://www.youtube.com/playlist?list=PL-NF6S9MM_W1QBjUc2B5Pg502bz7qslxk)** which pair the weekly blog with a question and answer hour. The recordings review the blog, cover questions, and feature a guest developer/engineer to talk about a more advanced subject.
+*   [Coursera training](https://www.coursera.org/specializations/internet-of-things)
+
+
+{% include image.html name="BrazilPartnershipGoImg4.jpg" alt="Dragonboard410c Partnership Brazil Image 4"%}
+
+</div>
+
+<div class="col-md-3" markdown="1">
+{% include image.html name="BrazilPartnershipGoImg3.jpg" alt="Dragonboard410c Partnership Brazil Image 3"%}
+
+{% include media.html media_url="https://www.youtube.com/embed/kIZd8CDgsWE?feature=oembed" %}
+
+* * *
+
+{% include media.html media_url="https://www.youtube.com/embed/videoseries?list=PL-NF6S9MM_W1QBjUc2B5Pg502bz7qslxk" %}
+
+</div>

--- a/go/coursera-96support/README.md
+++ b/go/coursera-96support/README.md
@@ -1,0 +1,12 @@
+---
+title: Coursera - 96Boards Support
+description: |-
+    This page will offer loads of resources and support channels along with links to any/all necessary materials to assist Coursera students with the UCSD / Qualcomm / 96Boards IoT Specialization.
+permalink: /go/coursera-96support/
+layout: empty-container-page-no-nav
+---
+
+## Coursera - 96Boards Support page
+
+Coming Soon...
+


### PR DESCRIPTION
These go pages will be worked on and eventually launched in the next few weeks.

- Coursera 96Support page will be launched within the next week
- Brazil Partnership page will be launched within next couple months.

Will add information to each page accordingly. Need official links for videos. 