### PR TITLE
Attempt to fix broken links in 2016-08 OpenHours blog

### DIFF
--- a/_posts/2016/08/2016-08-23-96boards-openhours-15-recap.md
+++ b/_posts/2016/08/2016-08-23-96boards-openhours-15-recap.md
@@ -420,27 +420,6 @@ DM
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-Contribution Policy [https://github.com/96boards/documentation/blob/master/ContributionPolicy.md](https://github.com/96boards/documentation/blob/master/Extras/ContributionPolicy.md)
-
-
-
-
-
-
-
-
 ![](https://ssl.gstatic.com/ui/v1/icons/mail/images/cleardot.gif)
 
 


### PR DESCRIPTION
Broken link found here: 2016-08-23-96boards-openhours-15-recap
referring to a link in the documentation that has since been changed.

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>