### PR TITLE
Small fix to chameleon96 and WISTEM go page

### DIFF
--- a/_product/ce/chameleon96/README.md
+++ b/_product/ce/chameleon96/README.md
@@ -12,7 +12,7 @@ redirect_from:
 ---
 # {{page.title}}
 
-The Chameleon96TM board, based on Intel® Cyclone V SoC FPGA, is a member of 96Boards community and complies with Consumer Edition board specifications. The Chameleon96TM meets all 96Boards mandatory specifications (excluding MIPI SDI Interface) and most optional specifications. The Chameleon96TM features Dual ARM Cortex-A9 processors and a set of peripherals allow direct interfacing and connecting to MMC/SD card, HDMI out, USB, WLAN and BLE. Two expansion connectors provide additional interfaces to cameras, USB, UARTs, I2C, SPI and GPIOs. The use of the FPGA fabric for the video processing allows development of custom IPU/GPU/VPU solutions on this platform.
+The Chameleon96TM board, based on Intel® Cyclone V SoC FPGA, is a member of 96Boards community and complies with Consumer Edition board specifications. The Chameleon96TM meets all 96Boards mandatory specifications (excluding MIPI DSI Interface) and most optional specifications. The Chameleon96TM features Dual ARM Cortex-A9 processors and a set of peripherals allow direct interfacing and connecting to MMC/SD card, HDMI out, USB, WLAN and BLE. Two expansion connectors provide additional interfaces to cameras, USB, UARTs, I2C, SPI and GPIOs. The use of the FPGA fabric for the video processing allows development of custom IPU/GPU/VPU solutions on this platform.
 
 ***
 

--- a/go/wistem-2018/README.md
+++ b/go/wistem-2018/README.md
@@ -9,8 +9,17 @@ layout: container-breadcrumb
 
 Coming soon...
 
+## The Schedule
+
+There will be several surprises and plenty of good times throughout the month of May. We have something planned for each day:
+
+- Up to 31 written interviews from Women in a wide variety of STEM fields
+   - Makers and software engineers, mathematicians and material physicists, Students, professionals, evangelists and influencers, we hope to speak with everyone!
+- Five x 1 hour long video interviews, streamed live, every week at the [end of the countdown](https://www.96boards.org/openhours/)
+   - This is your chance to listen in, share you thoughts, and even get your questions answered by a selected panel of core participants and our featured guest of the week.
+
 ## Get featured! Please take our Written Interview
 
-We are scouring the globe for influencial women who would like to share their story!
+We are scouring the globe for influencial women who would like to share their "STEM story"! To participate in this initiative, please take some time to fill out the interview questions below. Each interview will be highly considered for publishing, participants will notified if any action is taken.
 
 <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSc32F34PKNFfgq85Tfi-l3vKHu9X9L33asZngsPLTSNuAY5EQ/viewform?usp=sf_link" width="100%" height="1000" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>


### PR DESCRIPTION
- Fixed a typo in the Chameleon96 description on landing page
- Added more substance to go/wistem-2018 page
   - Added schedule section with draft content
   - Added greeting message to interview/form section

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>