### PR TITLE
Removed the Mailchimp JS include for a temporary fix to JQuery conflict issue.

### DIFF
--- a/assets/js/package-all-products.js
+++ b/assets/js/package-all-products.js
@@ -1,6 +1,5 @@
 //= require vendor/jquery
 //= require vendor/bootstrap
-//= require vendor/mc
 //= require vendor/cookieconsent
 //= require vendor/owl.carousel
 //= require vendor/lazysizes

--- a/assets/js/package-projects.js
+++ b/assets/js/package-projects.js
@@ -1,6 +1,5 @@
 //= require vendor/jquery
 //= require vendor/bootstrap
-//= require vendor/mc
 //= require vendor/cookieconsent
 //= require vendor/owl.carousel
 //= require vendor/lazysizes


### PR DESCRIPTION
Removed the Mailchimp JS include from the products/projects JS packages for a temporary fix to JQuery conflict issue.