### PR TITLE
developerbox: Adopt the same casing as the documentation

### DIFF
--- a/_product/ee/developerbox/README.md
+++ b/_product/ee/developerbox/README.md
@@ -1,5 +1,5 @@
 ---
-title: DeveloperBox (Socionext)
+title: Developerbox (Socionext)
 layout: product-display-page
 permalink: /product/developerbox/
 shortname: developerbox
@@ -26,7 +26,7 @@ product_tab_menu:
       tab_align_right: true 
 product_buy_links:
   -
-    link-title: DeveloperBox (Chip1Stop)
+    link-title: Developerbox (Chip1Stop)
     link-url: "http://www.chip1stop.com/web/USA/en/dispDetail.do?partId=SOCI-0000001&cid=SOCIEB"
     from: chip1stop.com
     type: board


### PR DESCRIPTION
I have been quite strict about spelling the board Developerbox (lowercase B)
in all the documentation. The reason for this is to discourage the view that
Developerbox is two words. Try searching for developer box" and "developerbox"
to see why!

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>