### PR TITLE
Fixes: 820c specs and Hikey960 link

### DIFF
--- a/_posts/2017/06/2017-06-01-googles-magenta-kernel-hikey-960.md
+++ b/_posts/2017/06/2017-06-01-googles-magenta-kernel-hikey-960.md
@@ -58,7 +58,7 @@ With a recent update to the source, Google added initial support for the HiKey96
 
 And the instructions to get it running on the HiKey960 can be found here:
 
-[https://github.com/fuchsia-mirror/magenta/blob/master/docs/targets/hikey960.md]()
+[https://fuchsia.googlesource.com/zircon/+/master/docs/targets/hikey960.md](https://fuchsia.googlesource.com/zircon/+/master/docs/targets/hikey960.md)
 
 
 # **Prerequisites and Troubleshooting**

--- a/_product/ce/dragonboard820c/README.md
+++ b/_product/ce/dragonboard820c/README.md
@@ -91,8 +91,8 @@ a commercial product.
 |   Component          |   Description                                                                  |
 |:---------------------|:-------------------------------------------------------------------------------|
 |  SoC                 | Qualcomm® Snapdragon™ 820E                                                     |
-|  CPU                 | Snapdragon 820E embedded platform, custom 64-bit Kryo quad-core CPU up to 2.35GHz , 14nm FinFET process technology                                                  |
-|  GPU                 | Adreno™ 530 GPU OpenGL ES 3.1 + AEP, Vulcan, Renderscript, 64-bit virtual addressing                                                                                  |
+|  CPU                 | Snapdragon 820E embedded platform, custom 64-bit Kryo quad-core CPU up to 2.15GHz , 14nm FinFET process technology                                                  |
+|  GPU                 | Adreno™ 530 GPU OpenGL ES 3.1 + AEP, OpenCL2.0, Vulcan, Renderscript, 64-bit virtual addressing                                                                                 |
 |  RAM                 | Quad-channel, 16bit, 3GB PoP LPDDR4 SDRAM designed for 1866 MHz clock rate                                              |
 |  Storage             | UFS2.0 gear 3 (1-lane) 32GB , and SD3.0                                              |
 |  Ethernet Port       | GbE Ethernet connection                                                        |
@@ -108,3 +108,5 @@ a commercial product.
 |  Power Source        | 96Boards compliant power supply                  |
 |  OS Support          | Linux Debian today<br>Linux OpenEmbedded – later 2018                          |
 |  Size                | 100mm by 85mm meeting 96Boards™ Consumer Edition ’extended’ dimensions specifications.               |
+
+>Note: OpenCL2.0, Vulcan and RenderScript are supported features on the GPU. However, they are NOT a part of the official Linux Kernel, Debian, Open-embedded and AOSP release.


### PR DESCRIPTION
- 820c: add note for unsupported api and corrected cpu clock speed
- changed link to hikey960 target for zircon(previously magenta) kernel.
fixes #326
fixes #633
Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>