### PR TITLE
go/2018-ultra96-contest: Added button back on page for hackster.io site

### DIFF
--- a/go/2018-ultra96-contest/README.md
+++ b/go/2018-ultra96-contest/README.md
@@ -12,6 +12,7 @@ js-package: openhours
 
 [Avnet](https://www.avnet.com/wps/portal/us/) and [Xilinx](https://www.xilinx.com/) have teamed up with [Hackster.io](https://www.hackster.io/) to launch a contest around the [Ultra96](https://www.96boards.org/product/ultra96/) (probably why you are here)! For those of you who don't know, the Ultra96 is part of the 96Boards Consumer Edition family, plenty more to read below... Naturally, the 96Boards team wanted to get involved with this exciting event!
 
+<a href="https://www.hackster.io/contests/ultra96" class="btn blog-read-more-btn center-block">Return to official Hackster.io Contest Page</a>
 <a href="https://www.96boards.org/go/2018-arm-contest/" class="btn blog-read-more-btn center-block">Use your Ultra96 in another contest! (Switch to Arm Page)</a>
 
 **On this page, you will find...**


### PR DESCRIPTION
Signed-off-by: Robert Wolff <robert.wolff@linaro.org>