### PR TITLE
go/2018-ultra96-contest: Removed workshop link until further notice

### DIFF
--- a/go/2018-ultra96-contest/README.md
+++ b/go/2018-ultra96-contest/README.md
@@ -64,7 +64,7 @@ js-package: openhours
 - **Projects**
    - Coming soon...
 - **Workshop**
-   - [Hackster.io Workshop](https://events.hackster.io/Ultra96)
+   - Coming soon...
 - **Blogs**
    - [96Boards Blogs](https://www.96boards.org/blog/)
    - [MicroZED Chronicles](https://blog.hackster.io/microzed-chronicles-a-look-at-the-ultra96-board-c5b8f7a02209)


### PR DESCRIPTION
Waiting on update from Hackster.io to update workshop link

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>