### PR TITLE
services: Attempt to add tabs to services page

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -6,6 +6,14 @@ permalink: "/services/"
 layout: container-breadcrumb
 css-package: openhours
 js-package: openhours
+product_tab_menu:
+  - tab_title: About
+    tab_link: /website/services/about/
+    tab_position: 1
+  - tab_title: Partners
+    tab_link: website/services/partners/
+    tab_position: 2
+    tab_align_right: true
 ---
 
 <div class="col-md-6" markdown="1">


### PR DESCRIPTION
Trying to take tab format from one of the product pages and applying it to the
services page. This might not work...

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>