### PR TITLE
Changed linaro.co links to http

### DIFF
--- a/_product/mezzanine/sensors-mezzanine/README.md
+++ b/_product/mezzanine/sensors-mezzanine/README.md
@@ -39,10 +39,10 @@ mezzanine_features:
 product_buy_links:
   -
     link-title: 96Boards Sensors
-    link-url: https://linaro.co/20n34bc
+    link-url: http://linaro.co/20n34bc
   -
     link-title: Grove Starter Kit for 96Boards
-    link-url: https://linaro.co/1KnV9TA
+    link-url: http://linaro.co/1KnV9TA
 product_more_info:
   - title: Getting-Started PDF
     link: http://linaro.co/sensorkitpdf


### PR DESCRIPTION
Changed linaro.co links to http seen as Seeed appears to be redirecting https requests with a 301 referral to their homepage...