### PR TITLE
link fixes

### DIFF
--- a/_data/sticky-tab-bar.yml
+++ b/_data/sticky-tab-bar.yml
@@ -343,7 +343,7 @@ pages:
         url: /documentation/enterprise/poplar-hoperun/
         sub-pages: true
       - title: Support
-        url: https://discuss.96boards.org/c/products/poplar-hoperun/
+        url: https://discuss.96boards.org/c/products/poplar/
         right: true
     sub-pages-enabled: true
     urls: [/documentation/enterprise/poplar-hoperun/]


### PR DESCRIPTION
Following links have been fixed

/documentation/enterprise/poplar-hoperun/additional-docs/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/build/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/getting-started/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/guides/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/hardware-docs/hw-user-manual.md.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/hardware-docs/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

/documentation/enterprise/poplar-hoperun/support/index.html:
https://discuss.96boards.org/c/products/poplar-hoperun/ [404]

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>