### PR TITLE
Updates to Avenger96 and OpenHours

### DIFF
--- a/_pages/openhours/README.md
+++ b/_pages/openhours/README.md
@@ -25,9 +25,14 @@ jumbotron:
 <a href="https://www.youtube.com/c/96Boards/" class="btn blog-read-more-btn center-block">Visit YouTube</a>
 <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=MWJjMGc3ZXMwYmh1NGFvMWhzNjJraGg5ZWdfMjAxOTA3MThUMTYwMDAwWiByb2JlcnQud29sZmZAbGluYXJvLm9yZw&tmsrc=robert.wolff%40linaro.org">Add to you Calendar</a>
 
-**Live from Snapcraft Summit - Montreal, Canada!**
+**Tech AMA Featuring Carl Perry of Packet**
 
-Who can we get from Snapcraft summit to talk to us live on OpenHours? Tune in to find out! There are folks from all walks of life here working on some of the coolest things. The hope is to speak with one of the event organizers, a representative from the ROS community and a board enablement pro! Come learn about Ubuntu Core, Snapcraft and ROS with us!
+This week, we will have Carl Perry as our featured guest! Generally speaking, this will be a tech AMA; however, you can expect this rowdy group of streamers to bring some fun topics of discussion to the table. If you plan to join the call through Zoom, feel free to join in on the conversation! If you have any cool tech lying around, let us know! We are glad to showcase any spur of the moment demos :-)
+
+**If you would like to learn more about Packet and the Works on Arm initiative, please poke throug the resources below:**
+
+- [Packet](https://www.packet.com/)
+- [Works on Arm](https://www.worksonarm.com/)
 
 Bring you questions & coffee and/or beer (water or juice :-P) and tune in at our regular time of 4:00p UTC on Thursday! See you there.
 

--- a/_pages/openhours/README.md
+++ b/_pages/openhours/README.md
@@ -23,7 +23,7 @@ jumbotron:
 <iframe width="350" height="120" src="https://w2.countingdownto.com/2050235" frameborder="0"></iframe><br />
 <a href="https://zoom.us/j/544757552" class="btn blog-read-more-btn center-block">Click Here to Join Zoom Webinar</a>
 <a href="https://www.youtube.com/c/96Boards/" class="btn blog-read-more-btn center-block">Visit YouTube</a>
-<a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=MWJjMGc3ZXMwYmh1NGFvMWhzNjJraGg5ZWdfMjAxOTA2MTNUMTYwMDAwWiByb2JlcnQud29sZmZAbGluYXJvLm9yZw&tmsrc=robert.wolff%40linaro.org">Add to you Calendar</a>
+<a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=MWJjMGc3ZXMwYmh1NGFvMWhzNjJraGg5ZWdfMjAxOTA3MThUMTYwMDAwWiByb2JlcnQud29sZmZAbGluYXJvLm9yZw&tmsrc=robert.wolff%40linaro.org">Add to you Calendar</a>
 
 **Live from Snapcraft Summit - Montreal, Canada!**
 

--- a/_product/ce/avenger96/README.md
+++ b/_product/ce/avenger96/README.md
@@ -38,11 +38,11 @@ product_support_link: "https://discuss.96boards.org/c/products/avenger96"
 # Buy Links
 product_buy_links:
   -
-    link-title: Avenger96 (Coming Soon...)
-    link-url: "https://www.arrow.com/en/campaigns/avengers"
+    link-title: Avenger96
+    link-url: "https://www.arrow.com/en/products/avenger96/arrow-development-tools"
     from: Arrow Electronics
     type: board
-    link-price: ""
+    link-price: "$149.00"
     link-price-currency: USD
 
 # Right Sidepanel links
@@ -55,6 +55,8 @@ product_more_info:
     link: https://github.com/96boards/documentation/blob/master/consumer/avenger96/hardware-docs/files/avenger96-hardware-user-manual.pdf
   - title: Schematics
   - link: https://github.com/96boards/documentation/blob/master/consumer/avenger96/hardware-docs/files/avenger96-schematics.pdf
+  - title: Arrow Campaign
+    link: https://www.arrow.com/en/campaigns/avengers
 
 # Bottom Link
 product_accessories:


### PR DESCRIPTION
- Add purchase link for Avenger96
- Move Arrow Campaign link to "More Info" Section
- Update OpenHours calendar link
- Update OpenHours Description

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>