### PR TITLE
Updated Download Section

### DIFF
--- a/_product/ie/orangepi-i96/README.md
+++ b/_product/ie/orangepi-i96/README.md
@@ -41,11 +41,7 @@ product_sidebar_sections:
           link: /documentation/iot/orangepi-i96/downloads/
         - title: Ubuntu Server
           link: /documentation/iot/orangepi-i96/downloads/
-        - title: Android Nand
-          link: /documentation/iot/orangepi-i96/downloads/
-        - title: Android Tcard
-          link: /documentation/iot/orangepi-i96/downloads/
-        - title: Raspbian Server
+        - title: Android
           link: /documentation/iot/orangepi-i96/downloads/
 attributes:
   - name: "SoC"


### PR DESCRIPTION
Some of the Download Options are not available anymore on the OrangePi Website.  Corrected it already in the Documentation and remove the non existing options from the Procuct Page as well, to not create confusion. 

Signed off by: Thore Krug opensource[at]thorekrug.de