### PR TITLE
CSS fix for markdown images being too large

### DIFF
--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -13,6 +13,12 @@
   object-fit: contain !important;
 }
 #wrapper {
+  .blog-content {
+    img {
+      width: 100%;
+      height: auto;
+    }
+  }
   #tabbed-nav-bar {
     position: relative;
     z-index: 99;


### PR DESCRIPTION
Simple CSS fix for plain markdown image includes. Images are not limited to the width of the main content container. However, images in blog posts should be added with the `image.html` include ensuring responsive images are generated. E.g

```
{% include image.html path="/assets/images/content/your-image.jpg" alt="An awesome image" %}
```